### PR TITLE
Reverb integration 

### DIFF
--- a/firmware/Src/hardware/FMDisplayMixer.cpp
+++ b/firmware/Src/hardware/FMDisplayMixer.cpp
@@ -372,21 +372,20 @@ void* FMDisplayMixer::getValuePointer(int valueType, int encoder) {
                      valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_PREDELAYMIX];
                      break;
                  case 5:
-                     valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_INPUTBASE];
+                     valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_NOTCHSPREAD];
                      break;
              }
              break;
          case MIXER_VALUE_GLOBAL_SETTINGS_4:
              switch (encoder) {
                  case 0:
-                     valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_INPUTWIDTH];
+                     valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_INPUTBASE];
                      break;
                  case 1:
-                     valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_NOTCHSPREAD];
+                     valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_INPUTWIDTH];
                      break;
                  case 2:
                      valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_LOOPHP];
-                     //valueP = (void*) &synthState_->mixerState.masterfxConfig[GLOBALFX_DIFFUSION];
                      break;
                  case 3:
                      valueP = (void*) &synthState_->mixerState.fxBus_.masterfxConfig[GLOBALFX_LFODEPTH];
@@ -710,17 +709,17 @@ void FMDisplayMixer::refreshMixerRowGlobalOptions(int page, int row) {
                     tft_->print("Pre delay Mix");
                     break;
                 case 5:
-                    tft_->print("Filter base");
+                    tft_->print("Notch Spread");
                     break;
             }
             break;
         case 3:
             switch (row) {
                 case 0:
-                    tft_->print("Filter width");
+                    tft_->print("Filter base");
                     break;
                 case 1:
-                    tft_->print("Notch Spread");
+                    tft_->print("Filter width");
                     break;
                 case 2:
                     tft_->print("Tank hp");

--- a/firmware/Src/synth/FxBus.cpp
+++ b/firmware/Src/synth/FxBus.cpp
@@ -373,11 +373,10 @@ void FxBus::paramChanged() {
     fxTimeLinear = masterfxConfig[GLOBALFX_PREDELAYTIME];
     if (prevFxTimeLinear == fxTimeLinear)
     {
-        prevTime     = clamp(fxTimeLinear, 0.0003f, 0.9996f);
-        prevTime     *= prevTime * prevTime;
-        fxTime         = fxTime * 0.9f + prevTime * 0.1f;
+        fxTime     = clamp(fxTimeLinear, 0.0003f, 0.9996f);
+        fxTime     *= fxTime * fxTime;
         predelaySize = fxTimeLinear * predelayBufferSizeM1;
-    }
+   }
     prevFxTimeLinear = fxTimeLinear;
 
     predelayMixLevel = masterfxConfig[GLOBALFX_PREDELAYMIX];
@@ -388,18 +387,17 @@ void FxBus::paramChanged() {
     {
         temp = lfoSpeedLinear;
         temp *= temp * temp;
-        lfoSpeed = lfoSpeed * 0.9f + temp * 0.1f;
+        lfoSpeed = temp;
     }
     prevLfoSpeedLinear = lfoSpeedLinear;
 
     temp = masterfxConfig[GLOBALFX_LFODEPTH];
     temp = temp * (1 - lfoSpeedLinear * 0.5f) * (1 - sizeParam * 0.5f);
-    lfoDepth = lfoDepth * 0.9f + temp * 0.1f;
+    lfoDepth = temp;
 
     // ------ page 2
 
-    nextSizeParam     = clamp(masterfxConfig[GLOBALFX_SIZE], 0.03f, 1);
-    sizeParam         = sizeParam * 0.99f + nextSizeParam * 0.01f;
+    sizeParam     = clamp(masterfxConfig[GLOBALFX_SIZE], 0.03f, 1);
 
     diffusion         =     masterfxConfig[GLOBALFX_DIFFUSION];
     damping         =     masterfxConfig[GLOBALFX_DAMPING];

--- a/firmware/Src/synth/FxBus.h
+++ b/firmware/Src/synth/FxBus.h
@@ -117,7 +117,7 @@ protected:
     float prevdecayVal = 0;
     float decayVal = 0.5, prevDecayVal = -1, decayFdbck = 0;
     const float decayMaxVal = 0.96f;
-    float sizeParam, prevSizeParam, nextSizeParam;
+    float sizeParam, prevSizeParam;
     float inputDiffusion, prevInputDiffusion;
     float diffusion, prevDiffusion;
     float damping, prevDamping = -1;


### PR DESCRIPTION
Bug sur le lissage des paramètres dans FxBus::paramChanged() : cette partie de code est maintenant appelée une seule fois la ou elle l'était en continu, dans les versions précédentes.

Changement de l'ordre d'affichage des paramètres de reverb : regroupement des params de filtre d'entrée