### PR TITLE
Reverbsend mod

### DIFF
--- a/firmware/Src/synth/FxBus.cpp
+++ b/firmware/Src/synth/FxBus.cpp
@@ -475,7 +475,7 @@ void FxBus::paramChanged() {
  */
 void FxBus::mixAdd(float *inStereo, float send, float reverbLevel) {
     if (send > 0) {
-        const float level = - panTable[(int)(send * 128)] * 0.0625f * reverbLevel;
+        const float level = - panTable[(int)(send * 255)] * 0.0625f * reverbLevel;
         
         totalSent += level;
 

--- a/firmware/Src/synth/Osc.cpp
+++ b/firmware/Src/synth/Osc.cpp
@@ -223,7 +223,11 @@ float Osc::getNoteRealFrequencyEstimation(struct OscState* oscState, float newNo
     case OSC_FT_FIXE:
         return oscState->mainFrequency;
     case OSC_FT_KEYHZ:
-        return newNoteFrequency *  oscillator->frequencyMul * (synthState_->mixerState.tuning_ * INV440) + oscillator->detune;
+        float freq = newNoteFrequency *  oscillator->frequencyMul * (synthState_->mixerState.tuning_ * INV440) + oscillator->detune;
+        if(freq < 0) {
+            freq = 0;
+        }
+        return freq;
     }
 }
 

--- a/firmware/Src/synth/Synth.cpp
+++ b/firmware/Src/synth/Synth.cpp
@@ -357,7 +357,7 @@ uint8_t Synth::buildNewSampleBlock(int32_t *buffer1, int32_t *buffer2, int32_t *
 
         // Max is 0x7fffff * [-1:1]
         //float sampleMultipler = (float) 0x7fffff;
-        float sampleMultipler = panTable[(int)((1 - synthState_->mixerState.instrumentState_[timbre].send) * 128)] * (float) 0x7fffff;
+        float sampleMultipler = panTable[(int)((1 - synthState_->mixerState.instrumentState_[timbre].send) * 255)] * (float) 0x7fffff;
 
         switch (synthState_->mixerState.instrumentState_[timbre].out) {
             // 0 => out1+out2, 1 => out1, 2=> out2


### PR DESCRIPTION
Changement du comportement du dry/wet de la reverb :

- de 0 à 0.5 : le volume du dry est constant, entrée progressive de la reverb jusqu'à son max à 0.5
- de 0.5 à 1 : disparition progressive du dry.

